### PR TITLE
Fix contrast for SkipTo Button text

### DIFF
--- a/packages/web-runtime/src/components/SkipTo.vue
+++ b/packages/web-runtime/src/components/SkipTo.vue
@@ -38,7 +38,7 @@ export default defineComponent({
   -webkit-appearance: none;
   border: none;
   background-color: var(--oc-color-swatch-brand-default);
-  color: var(--oc-color-text-inverse);
+  color: var(--oc-color-swatch-primary-contrast);
   font: inherit;
   padding: 0.25em 0.5em;
 }


### PR DESCRIPTION
## Description
Just stumbled upon the SkipTo button having a bad text contrasts (and violating a11y concerns) in dark mode

<img width="559" alt="Screenshot 2024-02-27 at 09 58 12" src="https://github.com/pascalwengerter/web/assets/16822008/1bd0ead6-0b19-43a8-b1ad-df0d4cc54bc1">
